### PR TITLE
Fix detect_max_pfn

### DIFF
--- a/kstream.c
+++ b/kstream.c
@@ -48,7 +48,7 @@ static bool kstream_block_valid(unsigned long start_pfn)
 
 static unsigned long kstream_detect_max_pfn(void)
 {
-	unsigned long end_pfn;
+	unsigned long end_pfn = 0;
 	int i;
 
 	for_each_online_node(i)


### PR DESCRIPTION
Uninitialized variable makes end_pfn start with a random value.

Signed-off-by: Eugenio Pérez <eperezma@redhat.com>